### PR TITLE
Streamline profile README around pinned projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-<h1 align="center">👋 Hola, soy <span title="@fcancela">Fernando Cancela</span></h1>
-<p align="center">Media Solutions Engineer focused on streaming reliability and delivery performance.</p>
+<h1 align="center">👋<span title="@fcancela">Fabián Cancela</span></h1>
+<p align="center">Media Solutions Engineer</p>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,48 @@
-### Hi there 👋
+<h1 align="center">👋 Hola, soy <span title="@fcancela">Fernando Cancela</span></h1>
+<p align="center">Media Solutions Engineer focused on streaming reliability and delivery performance.</p>
 
-<!--
-**fcancela/fcancela** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+---
 
-Here are some ideas to get you started:
+### 📌 Pinned projects
+<div align="center">
+  <table>
+    <tr>
+      <td>
+        <a href="https://github.com/fcancela/fcancela">
+          <img src="https://github-readme-stats.vercel.app/api/pin/?username=fcancela&repo=fcancela&theme=tokyonight" alt="fcancela profile repo" />
+        </a>
+      </td>
+      <td>
+        <a href="https://github.com/fcancela/fcancela.github.io">
+          <img src="https://github-readme-stats.vercel.app/api/pin/?username=fcancela&repo=fcancela.github.io&theme=tokyonight" alt="fcancela.github.io repo" />
+        </a>
+      </td>
+    </tr>
+  </table>
+</div>
 
-- 🔭 I’m currently working on ...
-- 🌱 I’m currently learning ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
-- 💬 Ask me about ...
-- 📫 How to reach me: ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
--->
+---
 
-![github stats](https://github-readme-stats.vercel.app/api?username=fcancela&show_icons=true&count_private=true)
+### 📊 Dynamic GitHub footprint
+> Objective signals only — counts and activity trends without exposing private content.
+
+<div align="center">
+  <table>
+    <tr>
+      <td>
+        <img src="https://github-readme-stats.vercel.app/api?username=fcancela&show_icons=true&theme=tokyonight&count_private=true" alt="GitHub stats" />
+      </td>
+      <td>
+        <img src="https://streak-stats.demolab.com?user=fcancela&theme=tokyonight&hide_border=false" alt="GitHub streak" />
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=fcancela&layout=compact&theme=tokyonight&langs_count=8" alt="Top languages" />
+      </td>
+      <td>
+        <img src="https://github-readme-activity-graph.vercel.app/graph?username=fcancela&theme=tokyo-night&area=true" alt="Contribution activity graph" />
+      </td>
+    </tr>
+  </table>
+</div>


### PR DESCRIPTION
## Summary
- strip out sales-style sections in favor of a concise profile intro
- highlight pinned projects via repo cards while retaining dynamic GitHub metrics
- keep objective, privacy-safe activity summaries

## Testing
- not run (README-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692304423134832cbb660ca29ffd042c)