### PR TITLE
Add animated banner and retro mission badges to profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 <p align="center">
   <img src="https://capsule-render.vercel.app/api?type=waving&height=220&color=0:0f172a,100:3b82f6&text=Fabian%20Cancela&fontAlign=50&fontAlignY=40&desc=Media%20Solutions%20Engineer%20%7C%20Streaming%20Reliability&descAlign=50&descAlignY=65&animation=twinkling&fontColor=E0E7FF" alt="Fabian Cancela banner" />
 </p>
-<h1 align="center">👋 Hola, soy <span title="@fcancela">Fabián Cancela</span></h1>
-<p align="center">Media Solutions Engineer focused on streaming reliability and delivery performance.</p>
 
 <p align="center">
   <img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=700&size=18&duration=2800&pause=700&color=38BDF8&center=true&vCenter=true&width=680&lines=Objective+signals+%7C+no+private+details+leaked;Streaming+observability%2C+delivery+pipelines%2C+edge+resilience;Open+source+tools+%E2%86%92+FFmpeg+%7C+SRT+%7C+NATS+%7C+OpenTelemetry" alt="Streaming focus typing animation" />
@@ -41,8 +39,6 @@
   <p>
     <img src="https://img.shields.io/badge/OSS%20stack-FFmpeg%20%7C%20SRT%20%7C%20NATS%20%7C%20OpenTelemetry-0ea5e9?style=for-the-badge&logo=opensourceinitiative&logoColor=white" alt="OSS stack" />
   </p>
-  <p><sub>Badges auto-update to keep the console lively without exposing private details.</sub></p>
-</div>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=700&size=18&duration=2800&pause=700&color=38BDF8&center=true&vCenter=true&width=680&lines=Objective+signals+%7C+no+private+details+leaked;Streaming+observability%2C+delivery+pipelines%2C+edge+resilience;Open+source+tools+%E2%86%92+FFmpeg+%7C+SRT+%7C+NATS+%7C+OpenTelemetry" alt="Streaming focus typing animation" />
+  <img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=700&size=18&duration=2800&pause=700&color=38BDF8&center=true&vCenter=true&width=680&lines=Streaming+observability%2C+delivery+pipelines%2C+edge+resilience;Open+source+tools+%E2%86%92+FFmpeg+%7C+SRT+%7C+NATS+%7C+OpenTelemetry" alt="Streaming focus typing animation" />
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
         <img src="https://github-readme-stats.vercel.app/api?username=fcancela&show_icons=true&theme=tokyonight&count_private=true" alt="GitHub stats" />
       </td>
       <td>
-        <img src="https://nirzak-streak-stats.vercel.app/?user=fcancela&theme=dark&hide_border=false" alt="GitHub streak" />
+        <img src="https://nirzak-streak-stats.vercel.app/?user=fcancela&theme=tokyonight&hide_border=false" alt="GitHub streak" />
       </td>
     </tr>
     <tr>

--- a/README.md
+++ b/README.md
@@ -1,18 +1,71 @@
-### Hi there 👋
+<p align="center">
+  <img src="https://capsule-render.vercel.app/api?type=waving&height=220&color=0:0f172a,100:3b82f6&text=Fernando%20Cancela&fontAlign=50&fontAlignY=40&desc=Media%20Solutions%20Engineer%20%7C%20Streaming%20Reliability&descAlign=50&descAlignY=65&animation=twinkling&fontColor=E0E7FF" alt="Fernando Cancela banner" />
+</p>
+<h1 align="center">👋 Hola, soy <span title="@fcancela">Fernando Cancela</span></h1>
+<p align="center">Media Solutions Engineer focused on streaming reliability and delivery performance.</p>
 
-<!--
-**fcancela/fcancela** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+<p align="center">
+  <img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=700&size=18&duration=2800&pause=700&color=38BDF8&center=true&vCenter=true&width=680&lines=Objective+signals+%7C+no+private+details+leaked;Streaming+observability%2C+delivery+pipelines%2C+edge+resilience;Open+source+tools+%E2%86%92+FFmpeg+%7C+SRT+%7C+NATS+%7C+OpenTelemetry" alt="Streaming focus typing animation" />
+</p>
 
-Here are some ideas to get you started:
+---
 
-- 🔭 I’m currently working on ...
-- 🌱 I’m currently learning ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
-- 💬 Ask me about ...
-- 📫 How to reach me: ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
--->
+### 📌 Pinned projects
+<div align="center">
+  <table>
+    <tr>
+      <td>
+        <a href="https://github.com/fcancela/fcancela">
+          <img src="https://github-readme-stats.vercel.app/api/pin/?username=fcancela&repo=fcancela&theme=tokyonight" alt="fcancela profile repo" />
+        </a>
+      </td>
+      <td>
+        <a href="https://github.com/fcancela/fcancela.github.io">
+          <img src="https://github-readme-stats.vercel.app/api/pin/?username=fcancela&repo=fcancela.github.io&theme=tokyonight" alt="fcancela.github.io repo" />
+        </a>
+      </td>
+    </tr>
+  </table>
+</div>
 
-![github stats](https://github-readme-stats.vercel.app/api?username=fcancela&show_icons=true&count_private=true)
+---
+
+### 🕹️ Retro mission panel (for fun)
+<div align="center">
+  <p>
+    <img src="https://img.shields.io/github/commit-activity/y/fcancela/fcancela?label=commit%20tempo&color=22d3ee&logo=github" alt="Commit tempo" />
+    <img src="https://img.shields.io/github/last-commit/fcancela/fcancela?label=latest%20push&color=a855f7&logo=github" alt="Latest push" />
+    <img src="https://img.shields.io/github/followers/fcancela?label=followers&color=10b981&logo=github" alt="Followers" />
+    <img src="https://img.shields.io/github/stars/fcancela/fcancela?label=repo%20stars&color=f59e0b&logo=apachespark" alt="Stars" />
+  </p>
+  <p>
+    <img src="https://img.shields.io/badge/OSS%20stack-FFmpeg%20%7C%20SRT%20%7C%20NATS%20%7C%20OpenTelemetry-0ea5e9?style=for-the-badge&logo=opensourceinitiative&logoColor=white" alt="OSS stack" />
+  </p>
+  <p><sub>Badges auto-update to keep the console lively without exposing private details.</sub></p>
+</div>
+
+---
+
+### 📊 Dynamic GitHub footprint
+> Objective signals only — counts and activity trends without exposing private content.
+
+<div align="center">
+  <table>
+    <tr>
+      <td>
+        <img src="https://github-readme-stats.vercel.app/api?username=fcancela&show_icons=true&theme=tokyonight&count_private=true" alt="GitHub stats" />
+      </td>
+      <td>
+        <img src="https://streak-stats.demolab.com?user=fcancela&theme=tokyonight&hide_border=false" alt="GitHub streak" />
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=fcancela&layout=compact&theme=tokyonight&langs_count=8" alt="Top languages" />
+      </td>
+      <td>
+        <img src="https://github-readme-activity-graph.vercel.app/graph?username=fcancela&theme=tokyo-night&area=true" alt="Contribution activity graph" />
+      </td>
+    </tr>
+  </table>
+</div>

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 <p align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&height=220&color=0:0f172a,100:3b82f6&text=Fabian%20Cancela&fontAlign=50&fontAlignY=40&desc=Media%20Solutions%20Engineer%20%7C%20Streaming%20Reliability&descAlign=50&descAlignY=65&animation=twinkling&fontColor=E0E7FF" alt="Fabian Cancela banner" />
+  <img src="https://capsule-render.vercel.app/api?type=waving&height=220&color=0:0f172a,100:3b82f6&text=Fabian%20Cancela&fontAlign=50&fontAlignY=40&desc=Media%20and%20streaming%20engineer&descAlign=50&descAlignY=65&animation=twinkling&fontColor=E0E7FF" alt="Fabian Cancela banner" />
+</p><p align="center">
+  <img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=700&size=18&duration=2800&pause=700&color=38BDF8&center=true&vCenter=true&width=680&lines=Video+streaming+pipelines+and+observability;FFmpeg+%7C+SRT+%7C+NATS+%7C+OpenTelemetry" alt="Streaming focus typing animation" />
 </p>
-
-<p align="center">
-  <img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=700&size=18&duration=2800&pause=700&color=38BDF8&center=true&vCenter=true&width=680&lines=Streaming+observability%2C+delivery+pipelines%2C+edge+resilience;Open+source+tools+%E2%86%92+FFmpeg+%7C+SRT+%7C+NATS+%7C+OpenTelemetry" alt="Streaming focus typing animation" />
-</p>
-
 ---
 
-### 📌 Pinned projects
+Pinned projects
+
 <div align="center">
   <table>
     <tr>
@@ -25,25 +23,24 @@
     </tr>
   </table>
 </div>
-
 ---
 
-### 🕹️ Retro mission panel (for fun)
+Repo signals
+
 <div align="center">
   <p>
-    <img src="https://img.shields.io/github/commit-activity/y/fcancela/fcancela?label=commit%20tempo&color=22d3ee&logo=github" alt="Commit tempo" />
-    <img src="https://img.shields.io/github/last-commit/fcancela/fcancela?label=latest%20push&color=a855f7&logo=github" alt="Latest push" />
+    <img src="https://img.shields.io/github/commit-activity/y/fcancela/fcancela?label=commit%20activity&color=22d3ee&logo=github" alt="Commit activity" />
+    <img src="https://img.shields.io/github/last-commit/fcancela/fcancela?label=latest%20commit&color=a855f7&logo=github" alt="Latest commit" />
     <img src="https://img.shields.io/github/followers/fcancela?label=followers&color=10b981&logo=github" alt="Followers" />
     <img src="https://img.shields.io/github/stars/fcancela/fcancela?label=repo%20stars&color=f59e0b&logo=apachespark" alt="Stars" />
   </p>
   <p>
-    <img src="https://img.shields.io/badge/OSS%20stack-FFmpeg%20%7C%20SRT%20%7C%20NATS%20%7C%20OpenTelemetry-0ea5e9?style=for-the-badge&logo=opensourceinitiative&logoColor=white" alt="OSS stack" />
+    <img src="https://img.shields.io/badge/Stack-FFmpeg%20%7C%20SRT%20%7C%20NATS%20%7C%20OpenTelemetry-0ea5e9?style=for-the-badge&logo=opensourceinitiative&logoColor=white" alt="Stack" />
   </p>
-
+</div>
 ---
 
-### 📊 Dynamic GitHub footprint
-> Objective signals only — counts and activity trends without exposing private content.
+GitHub metrics
 
 <div align="center">
   <table>

--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
 </p><p align="center">
   <img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=700&size=18&duration=2800&pause=700&color=38BDF8&center=true&vCenter=true&width=680&lines=Video+streaming+pipelines+and+observability;FFmpeg+%7C+SRT+%7C+NATS+%7C+OpenTelemetry" alt="Streaming focus typing animation" />
 </p>
----
-
-Pinned projects
 
 <div align="center">
   <table>
@@ -23,9 +20,6 @@ Pinned projects
     </tr>
   </table>
 </div>
----
-
-Repo signals
 
 <div align="center">
   <p>
@@ -38,9 +32,6 @@ Repo signals
     <img src="https://img.shields.io/badge/Stack-FFmpeg%20%7C%20SRT%20%7C%20NATS%20%7C%20OpenTelemetry-0ea5e9?style=for-the-badge&logo=opensourceinitiative&logoColor=white" alt="Stack" />
   </p>
 </div>
----
-
-GitHub metrics
 
 <div align="center">
   <table>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&height=220&color=0:0f172a,100:3b82f6&text=Fernando%20Cancela&fontAlign=50&fontAlignY=40&desc=Media%20Solutions%20Engineer%20%7C%20Streaming%20Reliability&descAlign=50&descAlignY=65&animation=twinkling&fontColor=E0E7FF" alt="Fernando Cancela banner" />
+  <img src="https://capsule-render.vercel.app/api?type=waving&height=220&color=0:0f172a,100:3b82f6&text=Fabian%20Cancela&fontAlign=50&fontAlignY=40&desc=Media%20Solutions%20Engineer%20%7C%20Streaming%20Reliability&descAlign=50&descAlignY=65&animation=twinkling&fontColor=E0E7FF" alt="Fabian Cancela banner" />
 </p>
-<h1 align="center">👋 Hola, soy <span title="@fcancela">Fernando Cancela</span></h1>
+<h1 align="center">👋 Hola, soy <span title="@fcancela">Fabián Cancela</span></h1>
 <p align="center">Media Solutions Engineer focused on streaming reliability and delivery performance.</p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 <p align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&height=220&color=0:0f172a,100:3b82f6&text=Fabian%20Cancela&fontAlign=50&fontAlignY=40&desc=Media%20and%20streaming%20engineer&descAlign=50&descAlignY=65&animation=twinkling&fontColor=E0E7FF" alt="Fabian Cancela banner" />
-</p><p align="center">
-  <img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=700&size=18&duration=2800&pause=700&color=38BDF8&center=true&vCenter=true&width=680&lines=Video+streaming+pipelines+and+observability;FFmpeg+%7C+SRT+%7C+NATS+%7C+OpenTelemetry" alt="Streaming focus typing animation" />
+  <img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=700&size=18&duration=2800&pause=700&color=38BDF8&center=true&vCenter=true&width=680&lines=Media+Solutions+Engineer;Building+%7C+Media+%7C+Tech+%7C+Together" alt="Streaming focus typing animation" />
 </p>
 
 <div align="center">
@@ -40,7 +38,7 @@
         <img src="https://github-readme-stats.vercel.app/api?username=fcancela&show_icons=true&theme=tokyonight&count_private=true" alt="GitHub stats" />
       </td>
       <td>
-        <img src="https://streak-stats.demolab.com?user=fcancela&theme=tokyonight&hide_border=false" alt="GitHub streak" />
+        <img src="https://nirzak-streak-stats.vercel.app/?user=fcancela&theme=dark&hide_border=false" alt="GitHub streak" />
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
## Summary
- add an animated capsule banner plus typing animation to spotlight the streaming focus without extra copy
- introduce a retro mission panel of auto-updating badges for commit tempo, latest push, followers, stars, and OSS stack
- retain the pinned projects and existing dynamic GitHub footprint

## Testing
- not run (README-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692304423134832cbb660ca29ffd042c)