### PR TITLE
Redesign profile README: broadcast aesthetic, curated content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,102 @@
+<!--
+  Fabián Cancela — GitHub profile README
+  Broadcast / live-sports aesthetic. Dark, electric, on-air energy.
+  NOTE: GitHub strips JS, so true mouse/scroll interactivity isn't possible here.
+  The animation below is an animated SVG served as an image. The real interactive
+  pixel-art experience lives on rightful.live.
+-->
+
 <p align="center">
-  <img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=700&size=18&duration=2800&pause=700&color=38BDF8&center=true&vCenter=true&width=680&lines=Media+Solutions+Engineer;Building+%7C+Media+%7C+Tech+%7C+Together" alt="Streaming focus typing animation" />
+  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:0EA5E9,45:6366F1,100:F59E0B&height=210&section=header&text=Fabi%C3%A1n%20Cancela&fontSize=58&fontColor=ffffff&animation=fadeIn&fontAlignY=36&desc=Founder%20%C2%B7%20Media%20%26%20Streaming%20Engineer%20%C2%B7%20Live%20Sports%20Tech&descAlignY=56&descSize=18&descAlignX=50" alt="Fabián Cancela" />
 </p>
 
-<div align="center">
-  <table>
-    <tr>
-      <td>
-        <a href="https://github.com/fcancela/fcancela">
-          <img src="https://github-readme-stats.vercel.app/api/pin/?username=fcancela&repo=fcancela&theme=tokyonight" alt="fcancela profile repo" />
-        </a>
-      </td>
-      <td>
-        <a href="https://github.com/fcancela/fcancela.github.io">
-          <img src="https://github-readme-stats.vercel.app/api/pin/?username=fcancela&repo=fcancela.github.io&theme=tokyonight" alt="fcancela.github.io repo" />
-        </a>
-      </td>
-    </tr>
-  </table>
-</div>
+<p align="center">
+  <img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=600&size=20&duration=3000&pause=900&color=38BDF8&center=true&vCenter=true&width=720&lines=Building+the+licensing+layer+for+live+sports;FFmpeg+%C2%B7+SRT+%C2%B7+WebRTC+%C2%B7+real-time+video+pipelines;Clips+fund+it+%C2%B7+Live+drives+it+%C2%B7+Data+defends+it;Entrepreneur+in+Residence+%40+Montevideo+Tech+Ventures" alt="What I build" />
+</p>
 
-<div align="center">
-  <p>
-    <img src="https://img.shields.io/github/commit-activity/y/fcancela/fcancela?label=commit%20activity&color=22d3ee&logo=github" alt="Commit activity" />
-    <img src="https://img.shields.io/github/last-commit/fcancela/fcancela?label=latest%20commit&color=a855f7&logo=github" alt="Latest commit" />
-    <img src="https://img.shields.io/github/followers/fcancela?label=followers&color=10b981&logo=github" alt="Followers" />
-    <img src="https://img.shields.io/github/stars/fcancela/fcancela?label=repo%20stars&color=f59e0b&logo=apachespark" alt="Stars" />
-  </p>
-  <p>
-    <img src="https://img.shields.io/badge/Stack-FFmpeg%20%7C%20SRT%20%7C%20NATS%20%7C%20OpenTelemetry-0ea5e9?style=for-the-badge&logo=opensourceinitiative&logoColor=white" alt="Stack" />
-  </p>
-</div>
+<p align="center">
+  <img src="https://img.shields.io/badge/%E2%97%89_ON_AIR-LIVE-EF4444?style=for-the-badge&labelColor=0B0F1A" alt="On air" />
+  <img src="https://img.shields.io/badge/Based_in-Montevideo,_Uruguay-10B981?style=for-the-badge&labelColor=0B0F1A" alt="Location" />
+  <img src="https://img.shields.io/badge/Open_to-Media_%C2%B7_Sports_%C2%B7_Streaming-F59E0B?style=for-the-badge&labelColor=0B0F1A" alt="Open to" />
+</p>
 
-<div align="center">
-  <table>
-    <tr>
-      <td>
-        <img src="https://github-readme-stats.vercel.app/api?username=fcancela&show_icons=true&theme=tokyonight&count_private=true" alt="GitHub stats" />
-      </td>
-      <td>
-        <img src="https://nirzak-streak-stats.vercel.app/?user=fcancela&theme=tokyonight&hide_border=false" alt="GitHub streak" />
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=fcancela&layout=compact&theme=tokyonight&langs_count=8" alt="Top languages" />
-      </td>
-      <td>
-        <img src="https://github-readme-activity-graph.vercel.app/graph?username=fcancela&theme=tokyo-night&area=true" alt="Contribution activity graph" />
-      </td>
-    </tr>
-  </table>
-</div>
+---
+
+### `>` whoami
+
+I build the technology behind **live sports and entertainment** — the pipelines, the rights, and the real-time video that move broadcast moments from the stadium to the world.
+
+Right now I'm **Entrepreneur in Residence at [Montevideo Tech Ventures](https://montevideotech.ventures)**, founding **[Rightful](https://rightful.live)** — the licensing layer that lets leagues, creators, and brands co-create and monetize derivative sports content with rights cleared automatically. I work end-to-end: from the **server-side video compositor** and **live co-streaming engine** to the **AI clip-manufacturing pipeline** and the business model around it.
+
+My north star: **media × entertainment × live events × sports × technology.**
+
+---
+
+### `>` what I'm building
+
+<table>
+  <tr>
+    <td width="60">🏟️</td>
+    <td>
+      <strong><a href="https://rightful.live">Rightful</a></strong> — <em>the licensing layer for derivative sports content.</em><br/>
+      A three-sided clearing engine matching leagues + creators + brands. Owned footage in → personalized, rights-clean, sponsor-branded clips out → live co-streaming as the upsell, with a server-side compositor so creators never touch the master feed. <strong>Clips fund it · Live drives it · Data defends it.</strong>
+    </td>
+  </tr>
+</table>
+
+---
+
+### `>` stack
+
+**Media & Streaming**
+
+![FFmpeg](https://img.shields.io/badge/FFmpeg-007808?style=for-the-badge&logo=ffmpeg&logoColor=white)
+![WebRTC](https://img.shields.io/badge/WebRTC-333333?style=for-the-badge&logo=webrtc&logoColor=white)
+![SRT](https://img.shields.io/badge/SRT-FF6B00?style=for-the-badge&logo=files&logoColor=white)
+![LiveKit](https://img.shields.io/badge/LiveKit-1FD5F9?style=for-the-badge&logo=livekit&logoColor=black)
+![HLS](https://img.shields.io/badge/HLS%20%2F%20RTMP-EF4444?style=for-the-badge&logo=apple&logoColor=white)
+![NATS](https://img.shields.io/badge/NATS-27AAE1?style=for-the-badge&logo=natsdotio&logoColor=white)
+
+**Backend & Languages**
+
+![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white)
+![Node.js](https://img.shields.io/badge/Node.js-339933?style=for-the-badge&logo=node.js&logoColor=white)
+![Go](https://img.shields.io/badge/Go-00ADD8?style=for-the-badge&logo=go&logoColor=white)
+![Python](https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white)
+![Express](https://img.shields.io/badge/Express-000000?style=for-the-badge&logo=express&logoColor=white)
+
+**AI & Data**
+
+![OpenAI](https://img.shields.io/badge/OpenAI-412991?style=for-the-badge&logo=openai&logoColor=white)
+![AWS Bedrock](https://img.shields.io/badge/AWS%20Bedrock-FF9900?style=for-the-badge&logo=amazonaws&logoColor=white)
+![Twelve Labs](https://img.shields.io/badge/Twelve%20Labs-7C3AED?style=for-the-badge&logo=v&logoColor=white)
+![pgvector](https://img.shields.io/badge/pgvector-4169E1?style=for-the-badge&logo=postgresql&logoColor=white)
+
+**Cloud & Infra**
+
+![AWS](https://img.shields.io/badge/AWS-232F3E?style=for-the-badge&logo=amazonaws&logoColor=white)
+![Supabase](https://img.shields.io/badge/Supabase-3FCF8E?style=for-the-badge&logo=supabase&logoColor=white)
+![Docker](https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white)
+![OpenTelemetry](https://img.shields.io/badge/OpenTelemetry-000000?style=for-the-badge&logo=opentelemetry&logoColor=white)
+![Remotion](https://img.shields.io/badge/Remotion-0B84F3?style=for-the-badge&logo=remotion&logoColor=white)
+
+**Frontend**
+
+![React](https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB)
+![Vite](https://img.shields.io/badge/Vite-646CFF?style=for-the-badge&logo=vite&logoColor=white)
+![Tailwind CSS](https://img.shields.io/badge/Tailwind-06B6D4?style=for-the-badge&logo=tailwindcss&logoColor=white)
+
+---
+
+### `>` connect
+
+<p align="left">
+  <!-- TODO: add LinkedIn — <a href="https://www.linkedin.com/in/YOUR-HANDLE"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn" /></a> -->
+  <a href="https://rightful.live"><img src="https://img.shields.io/badge/rightful.live-0EA5E9?style=for-the-badge&logo=rocket&logoColor=white" alt="Rightful" /></a>
+  <a href="https://montevideotech.ventures"><img src="https://img.shields.io/badge/Montevideo_Tech_Ventures-6366F1?style=for-the-badge&logo=safari&logoColor=white" alt="Montevideo Tech Ventures" /></a>
+  <a href="mailto:fabian@montevideotech.ventures"><img src="https://img.shields.io/badge/Email-F59E0B?style=for-the-badge&logo=gmail&logoColor=white" alt="Email" /></a>
+</p>
+
+<p align="center">
+  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:F59E0B,55:6366F1,100:0EA5E9&height=120&section=footer" alt="" />
+</p>

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ My north star: **media × entertainment × live events × sports × technology.*
 ### `>` connect
 
 <p align="left">
-  <!-- TODO: add LinkedIn — <a href="https://www.linkedin.com/in/YOUR-HANDLE"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn" /></a> -->
+  <a href="https://www.linkedin.com/in/fcancela/"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn" /></a>
   <a href="https://rightful.live"><img src="https://img.shields.io/badge/rightful.live-0EA5E9?style=for-the-badge&logo=rocket&logoColor=white" alt="Rightful" /></a>
   <a href="https://montevideotech.ventures"><img src="https://img.shields.io/badge/Montevideo_Tech_Ventures-6366F1?style=for-the-badge&logo=safari&logoColor=white" alt="Montevideo Tech Ventures" /></a>
   <a href="mailto:fabian@montevideotech.ventures"><img src="https://img.shields.io/badge/Email-F59E0B?style=for-the-badge&logo=gmail&logoColor=white" alt="Email" /></a>


### PR DESCRIPTION
Replaces the old README that had broken widgets.

## Why
- The pinned card pointed at `fcancela.github.io` (doesn't exist) → "User Repository Not found".
- Stats / streak / top-languages cards render empty or errored because the code repos are **private** — those APIs can't read private repos, so they'll always look broken.

## What changed
- Removed all auto-stat widgets.
- Hand-written, on-brand broadcast profile: animated waving header, typing taglines, `whoami`, Rightful highlight (public-safe framing only), grouped tech stack, contact links.
- Confidential business details (financials, funding, partner names, take rates) deliberately excluded.

## TODO before/after merge
- Add LinkedIn URL (placeholder comment left in the `connect` section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)