### PR TITLE
Self-host header/footer SVGs (drop flaky capsule-render)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 -->
 
 <p align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:0EA5E9,45:6366F1,100:F59E0B&height=210&section=header&text=Fabi%C3%A1n%20Cancela&fontSize=58&fontColor=ffffff&animation=fadeIn&fontAlignY=36&desc=Founder%20%C2%B7%20Media%20%26%20Streaming%20Engineer%20%C2%B7%20Live%20Sports%20Tech&descAlignY=56&descSize=18&descAlignX=50" alt="Fabián Cancela" />
+  <img src="https://raw.githubusercontent.com/fcancela/fcancela/main/assets/header.svg" alt="Fabián Cancela — Founder · Media & Streaming Engineer · Live Sports Tech" />
 </p>
 
 <p align="center">
@@ -98,5 +98,5 @@ My north star: **media × entertainment × live events × sports × technology.*
 </p>
 
 <p align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:F59E0B,55:6366F1,100:0EA5E9&height=120&section=footer" alt="" />
+  <img src="https://raw.githubusercontent.com/fcancela/fcancela/main/assets/footer.svg" alt="" />
 </p>

--- a/assets/footer.svg
+++ b/assets/footer.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="120" viewBox="0 0 1200 120" fill="none" role="img" aria-label="">
+  <defs>
+    <linearGradient id="fw1" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#F59E0B"/>
+      <stop offset="0.55" stop-color="#6366F1"/>
+      <stop offset="1" stop-color="#0EA5E9"/>
+    </linearGradient>
+    <linearGradient id="fw2" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#0EA5E9"/>
+      <stop offset="1" stop-color="#6366F1"/>
+    </linearGradient>
+  </defs>
+  <g opacity="0.5">
+    <path fill="url(#fw2)" d="M-1200,44 q150,28 300,0 t300,0 t300,0 t300,0 t300,0 t300,0 t300,0 t300,0 V0 H-1200 Z">
+      <animateTransform attributeName="transform" type="translate" from="0 0" to="1200 0" dur="12s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <g opacity="0.95">
+    <path fill="url(#fw1)" d="M-1200,30 q150,30 300,0 t300,0 t300,0 t300,0 t300,0 t300,0 t300,0 t300,0 V0 H-1200 Z">
+      <animateTransform attributeName="transform" type="translate" from="0 0" to="-1200 0" dur="9s" repeatCount="indefinite"/>
+    </path>
+  </g>
+</svg>

--- a/assets/header.svg
+++ b/assets/header.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="220" viewBox="0 0 1200 220" fill="none" role="img" aria-label="Fabián Cancela — Founder, Media & Streaming Engineer, Live Sports Tech">
+  <defs>
+    <linearGradient id="wave1" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#0EA5E9"/>
+      <stop offset="0.5" stop-color="#6366F1"/>
+      <stop offset="1" stop-color="#F59E0B"/>
+    </linearGradient>
+    <linearGradient id="wave2" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#6366F1"/>
+      <stop offset="1" stop-color="#0EA5E9"/>
+    </linearGradient>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0B0F1A"/>
+      <stop offset="1" stop-color="#0E1424"/>
+    </linearGradient>
+  </defs>
+
+  <!-- background -->
+  <rect width="1200" height="220" fill="url(#bg)"/>
+
+  <!-- flowing waves (each tile is 1200 wide; translate one tile for a seamless loop) -->
+  <g opacity="0.55">
+    <path fill="url(#wave2)" d="M-1200,176 q150,-26 300,0 t300,0 t300,0 t300,0 t300,0 t300,0 t300,0 t300,0 V220 H-1200 Z">
+      <animateTransform attributeName="transform" type="translate" from="0 0" to="1200 0" dur="11s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <g opacity="0.9">
+    <path fill="url(#wave1)" d="M-1200,190 q150,-30 300,0 t300,0 t300,0 t300,0 t300,0 t300,0 t300,0 t300,0 V220 H-1200 Z">
+      <animateTransform attributeName="transform" type="translate" from="0 0" to="-1200 0" dur="8s" repeatCount="indefinite"/>
+    </path>
+  </g>
+
+  <!-- ON AIR pill (top-right), blinking dot -->
+  <g transform="translate(1024,26)">
+    <rect width="150" height="30" rx="15" fill="#111827" stroke="#1F2937"/>
+    <circle cx="22" cy="15" r="6" fill="#EF4444">
+      <animate attributeName="opacity" values="1;0.25;1" dur="1.4s" repeatCount="indefinite"/>
+    </circle>
+    <text x="40" y="20" font-family="'JetBrains Mono','Courier New',monospace" font-size="13" font-weight="700" letter-spacing="2" fill="#F3F4F6">ON AIR</text>
+  </g>
+
+  <!-- equalizer bars (top-left) -->
+  <g transform="translate(40,18)" fill="#38BDF8">
+    <rect x="0"  y="6"  width="5" height="22" rx="2"><animate attributeName="height" values="22;8;22"  dur="0.9s" repeatCount="indefinite"/><animate attributeName="y" values="6;20;6" dur="0.9s" repeatCount="indefinite"/></rect>
+    <rect x="9"  y="2"  width="5" height="30" rx="2"><animate attributeName="height" values="30;12;30" dur="1.2s" repeatCount="indefinite"/><animate attributeName="y" values="2;16;2"  dur="1.2s" repeatCount="indefinite"/></rect>
+    <rect x="18" y="10" width="5" height="16" rx="2"><animate attributeName="height" values="16;28;16" dur="0.7s" repeatCount="indefinite"/><animate attributeName="y" values="10;1;10" dur="0.7s" repeatCount="indefinite"/></rect>
+    <rect x="27" y="4"  width="5" height="26" rx="2"><animate attributeName="height" values="26;10;26" dur="1.05s" repeatCount="indefinite"/><animate attributeName="y" values="4;18;4" dur="1.05s" repeatCount="indefinite"/></rect>
+  </g>
+
+  <!-- name + subtitle -->
+  <text x="600" y="118" text-anchor="middle" font-family="'JetBrains Mono','Segoe UI',sans-serif" font-size="58" font-weight="800" fill="#FFFFFF" letter-spacing="1">Fabián Cancela</text>
+  <text x="600" y="152" text-anchor="middle" font-family="'JetBrains Mono','Courier New',monospace" font-size="17" font-weight="500" fill="#94A3B8" letter-spacing="3">FOUNDER · MEDIA &amp; STREAMING ENGINEER · LIVE SPORTS TECH</text>
+</svg>


### PR DESCRIPTION
The hero banner intermittently failed because it depended on `capsule-render.vercel.app`, and GitHub's image proxy caches failed fetches.

## Fix
- Added `assets/header.svg` and `assets/footer.svg` — animated SVGs (waving gradient, ON AIR pill, equalizer bars) served from this repo.
- README now references them via raw.githubusercontent URLs. No third-party render service in the critical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)