### PR TITLE
Fix invalid XML in header.svg (raw ampersand)

### DIFF
--- a/assets/header.svg
+++ b/assets/header.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="220" viewBox="0 0 1200 220" fill="none" role="img" aria-label="Fabián Cancela — Founder, Media & Streaming Engineer, Live Sports Tech">
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="220" viewBox="0 0 1200 220" fill="none" role="img" aria-label="Fabián Cancela — Founder, Media &amp; Streaming Engineer, Live Sports Tech">
   <defs>
     <linearGradient id="wave1" x1="0" y1="0" x2="1" y2="0">
       <stop offset="0" stop-color="#0EA5E9"/>


### PR DESCRIPTION
A raw `&` in the SVG `aria-label` broke XML parsing (`xmlParseEntityRef: no name`), so the banner failed to render. Escaped to `&amp;`. Validated with an XML parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)