### PR TITLE
Modernize stack: lean terminal block, drop badge wall

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,43 +48,14 @@ My north star: **media × entertainment × live events × sports × technology.*
 
 ### `>` stack
 
-**Media & Streaming**
+```text
+realtime video   ffmpeg · webrtc · srt · hls/rtmp · livekit
+video ai         bedrock vlm · twelve labs · remotion lambda
+languages        typescript · go · python
+data + infra     postgres/pgvector · aurora · supabase · aws · docker · otel
+```
 
-![FFmpeg](https://img.shields.io/badge/FFmpeg-007808?style=for-the-badge&logo=ffmpeg&logoColor=white)
-![WebRTC](https://img.shields.io/badge/WebRTC-333333?style=for-the-badge&logo=webrtc&logoColor=white)
-![SRT](https://img.shields.io/badge/SRT-FF6B00?style=for-the-badge)
-![LiveKit](https://img.shields.io/badge/LiveKit-1FD5F9?style=for-the-badge&logo=livekit&logoColor=black)
-![HLS](https://img.shields.io/badge/HLS%20%2F%20RTMP-EF4444?style=for-the-badge&logo=apple&logoColor=white)
-![NATS](https://img.shields.io/badge/NATS-27AAE1?style=for-the-badge&logo=natsdotio&logoColor=white)
-
-**Backend & Languages**
-
-![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white)
-![Node.js](https://img.shields.io/badge/Node.js-339933?style=for-the-badge&logo=node.js&logoColor=white)
-![Go](https://img.shields.io/badge/Go-00ADD8?style=for-the-badge&logo=go&logoColor=white)
-![Python](https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white)
-![Express](https://img.shields.io/badge/Express-000000?style=for-the-badge&logo=express&logoColor=white)
-
-**AI & Data**
-
-![OpenAI](https://img.shields.io/badge/OpenAI-412991?style=for-the-badge&logo=openai&logoColor=white)
-![AWS Bedrock](https://img.shields.io/badge/AWS%20Bedrock-FF9900?style=for-the-badge&logo=amazonaws&logoColor=white)
-![Twelve Labs](https://img.shields.io/badge/Twelve%20Labs-7C3AED?style=for-the-badge)
-![pgvector](https://img.shields.io/badge/pgvector-4169E1?style=for-the-badge&logo=postgresql&logoColor=white)
-
-**Cloud & Infra**
-
-![AWS](https://img.shields.io/badge/AWS-232F3E?style=for-the-badge&logo=amazonaws&logoColor=white)
-![Supabase](https://img.shields.io/badge/Supabase-3FCF8E?style=for-the-badge&logo=supabase&logoColor=white)
-![Docker](https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white)
-![OpenTelemetry](https://img.shields.io/badge/OpenTelemetry-000000?style=for-the-badge&logo=opentelemetry&logoColor=white)
-![Remotion](https://img.shields.io/badge/Remotion-0B84F3?style=for-the-badge&logo=remotion&logoColor=white)
-
-**Frontend**
-
-![React](https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB)
-![Vite](https://img.shields.io/badge/Vite-646CFF?style=for-the-badge&logo=vite&logoColor=white)
-![Tailwind CSS](https://img.shields.io/badge/Tailwind-06B6D4?style=for-the-badge&logo=tailwindcss&logoColor=white)
+<sub>Heads-down on the things that move pixels in real time. Everything else is a detail.</sub>
 
 ---
 


### PR DESCRIPTION
The badge wall read dated. Replaced with a clean aligned monospace block grouped by domain (realtime video, video ai, languages, data+infra). Matches the `>` terminal motif and the less-is-more direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)